### PR TITLE
Replaced cmake/modules.FindMmg.cmake with updated version

### DIFF
--- a/cmake/modules/FindMmg.cmake
+++ b/cmake/modules/FindMmg.cmake
@@ -34,13 +34,12 @@
 #  MMG_LIBRARIES       - mmg component libraries to be linked
 #
 # The user can give specific paths where to find the libraries adding cmake
-# options at configure (ex: cmake path/to/project -DMMG_DIR=path/to/mmg):
+# options at configure (ex: cmake path/to/project -DMMG_DIR=path/to/mmg/install):
 #  MMG_DIR                  - Where to find the base directory of mmg
-#  MMG_INCDIR               - Where to find the header files
+#  MMG_INCDIR               - Path toward Mmg installation (should at least contains mmg/common filder)
 #  MMG_LIBDIR               - Where to find the library files
-#  MMG_BUILDDIR             - Where to find the build directory of Mmg
 # The module can also look for the following environment variables if paths
-# are not given as cmake variable: MMG_DIR, MMG_INCDIR, MMG_LIBDIR, MMG_BUILDDIR
+# are not given as cmake variable: MMG_DIR, MMG_INCDIR, MMG_LIBDIR
 
 if (NOT MMG_FOUND)
   set(MMG_DIR "" CACHE PATH "Installation directory of MMG library")
@@ -48,25 +47,6 @@ if (NOT MMG_FOUND)
     message(STATUS "A cache variable, namely MMG_DIR, has been set to specify the install directory of MMG")
   endif()
 endif()
-
-# Looking for the Mmg build directory
-# -----------------------------------
-set(ENV_MMG_BUILDDIR "$ENV{MMG_BUILDDIR}")
-
-if ( NOT MMG_BUILDDIR )
-  FIND_PATH(MMG_BUILDDIR_INTERNAL
-    NAMES src/common/mmgcommon.h
-    HINTS ${ENV_MMG_BUILDDIR} ${MMG_DIR} ${ENV_MMG_DIR}
-    PATH_SUFFIXES build Build BUILD builds Builds BUILDS
-    DOC "The mmg build directory"
-    )
-else ()
-  set(MMG_BUILDDIR_INTERNAL "${MMG_BUILDDIR}")
-endif()
-
-if ( NOT MMG_BUILDDIR AND MMG_BUILDDIR_INTERNAL )
-   SET ( MMG_BUILDDIR "${MMG_BUILDDIR_INTERNAL}" )
-endif ( )
 
 # Looking for include
 # -------------------
@@ -79,22 +59,10 @@ set(ENV_MMG_INCDIR "$ENV{MMG_INCDIR}")
 
 if(ENV_MMG_INCDIR)
   list(APPEND _inc_env "${ENV_MMG_INCDIR}")
-elseif(ENV_MMG_BUILDDIR)
-  list(APPEND _inc_env "${ENV_MMG_BUILDDIR}/include")
-  list(APPEND _inc_env "${ENV_MMG_BUILDDIR}/include/mmg")
 elseif(ENV_MMG_DIR)
-  if ( MMG_BUILDDIR )
-    list(APPEND _inc_env "${MMG_BUILDDIR}/include")
-    list(APPEND _inc_env "${MMG_BUILDDIR}/include/mmg")
-  else ( )
-    list(APPEND _inc_env "${ENV_MMG_DIR}")
-    list(APPEND _inc_env "${ENV_MMG_DIR}/include")
-    list(APPEND _inc_env "${ENV_MMG_DIR}/include/mmg")
-    if ( MMG_BUILDDIR_INTERNAL )
-      list(APPEND _inc_env "${MMG_BUILDDIR_INTERNAL}/include")
-      list(APPEND _inc_env "${MMG_BUILDDIR_INTERNAL}/include/mmg")
-    endif()
-  endif()
+  list(APPEND _inc_env "${ENV_MMG_DIR}")
+  list(APPEND _inc_env "${ENV_MMG_DIR}/include")
+  list(APPEND _inc_env "${ENV_MMG_DIR}/include/mmg")
 else()
   if(WIN32)
     string(REPLACE ":" ";" _inc_env "$ENV{INCLUDE}")
@@ -122,39 +90,24 @@ if(MMG_INCDIR)
   find_path(MMG_libmmgtypes.h_DIRS
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
-    PATH_SUFFIXES "mmg2d" "mmgs" "mmg3d")
-elseif(MMG_BUILDDIR)
-  set(MMG_libmmgtypes.h_DIRS "MMG_libmmgtypes.h_DIRS-NOTFOUND")
-  find_path(MMG_libmmgtypes.h_DIRS
-    NAMES libmmgtypes.h
-    HINTS ${MMG_BUILDDIR}
-    PATH_SUFFIXES "include" "include/mmg" "include/mmg/mmg2d"
-        "include/mmg/mmgs" "include/mmg/mmg3d")
+    PATH_SUFFIXES "mmg" "mmg/mmg2d" "mmg/mmgs" "mmg/mmg3d" "mmg/common" "mmg2d"
+    "mmgs" "mmg3d")
 else()
   if(MMG_DIR)
     set(MMG_libmmgtypes.h_DIRS "MMG_libmmgtypes.h_DIRS-NOTFOUND")
-    if ( MMG_BUILDDIR )
-      find_path(MMG_libmmgtypes.h_DIRS
-        NAMES */libmmgtypes.h
-        HINTS ${MMG_BUILDDIR}
-        PATH_SUFFIXES "include" "include/mmg" "include/mmg/mmg2d"
-        "include/mmg/mmgs" "include/mmg/mmg3d")
-    else()
-      find_path(MMG_libmmgtypes.h_DIRS
-        NAMES libmmgtypes.h
-        HINTS ${MMG_DIR} ${MMG_BUILDDIR_INTERNAL}
-        PATH_SUFFIXES "include" "include/mmg" "include/mmg/mmg2d"
-        "include/mmg/mmgs" "include/mmg/mmg3d")
-    endif()
-
+    find_path(MMG_libmmgtypes.h_DIRS
+      NAMES libmmgtypes.h
+      HINTS ${MMG_DIR}/include
+      PATH_SUFFIXES  "mmg" "mmg/common")
   else()
     set(MMG_libmmgtypes.h_DIRS "MMG_libmmgtypes.h_DIRS-NOTFOUND")
     find_path(MMG_libmmgtypes.h_DIRS
       NAMES libmmgtypes.h
-      HINTS ${_inc_env})
+      HINTS ${_inc_env}
+      PATH_SUFFIXES  "mmg" "mmg/common")
   endif()
 endif()
-STRING(REGEX REPLACE "(mmg/mmg2d)|(mmg/mmgs)|(mmg/mmg3d)" ""
+STRING(REGEX REPLACE "(mmg/mmg2d)|(mmg/mmgs)|(mmg/mmg3d)|(mmg/common)" ""
   MMG_libmmgtypes.h_DIRS ${MMG_libmmgtypes.h_DIRS})
 
 mark_as_advanced(MMG_libmmgtypes.h_DIRS)
@@ -181,19 +134,9 @@ unset(_lib_env)
 set(ENV_MMG_LIBDIR "$ENV{MMG_LIBDIR}")
 if(ENV_MMG_LIBDIR)
   list(APPEND _lib_env "${ENV_MMG_LIBDIR}")
-elseif(ENV_MMG_BUILDDIR)
-  list(APPEND _lib_env "${ENV_MMG_BUILDDIR}")
-  list(APPEND _lib_env "${ENV_MMG_BUILDDIR}/lib")
 elseif(ENV_MMG_DIR)
-  if ( MMG_BUILDDIR )
-    list(APPEND _lib_env "${MMG_BUILDDIR}/lib")
-  else ( )
-    list(APPEND _lib_env "${ENV_MMG_DIR}")
-    list(APPEND _lib_env "${ENV_MMG_DIR}/lib")
-    if ( MMG_BUILDDIR_INTERNAL )
-      list(APPEND _lib_env "${MMG_BUILDDIR_INTERNAL}/lib")
-    endif()
-  endif()
+  list(APPEND _lib_env "${ENV_MMG_DIR}")
+  list(APPEND _lib_env "${ENV_MMG_DIR}/lib")
 else()
   if(WIN32)
     string(REPLACE ":" ";" _lib_env "$ENV{LIB}")
@@ -221,17 +164,10 @@ else()
   if(MMG_DIR)
     set(MMG_mmg_LIBRARY "MMG_mmg_LIBRARY-NOTFOUND")
 
-    if ( MMG_BUILDDIR )
-      find_library(MMG_mmg_LIBRARY
-        NAMES mmg
-        HINTS ${MMG_BUILDDIR}
-        PATH_SUFFIXES lib lib32 lib64)
-    else ()
-      find_library(MMG_mmg_LIBRARY
-        NAMES mmg
-        HINTS ${MMG_DIR} ${MMG_BUILDDIR_INTERNAL}
-        PATH_SUFFIXES lib lib32 lib64)
-    endif()
+    find_library(MMG_mmg_LIBRARY
+      NAMES mmg
+      HINTS ${MMG_DIR}
+      PATH_SUFFIXES "lib" "lib32" "lib64")
   else()
     set(MMG_mmg_LIBRARY "MMG_mmg_LIBRARY-NOTFOUND")
     find_library(MMG_mmg_LIBRARY


### PR DESCRIPTION
The installation tree of Mmg has been modified by release `5.7.0`: now, common headers are installed in the new `mmg/common` subdirectory. In consequence, the old `FindMMG.cmake` file doesn't work anymore.