### PR TITLE
Added a missing initialization of several variables when reading input mesh

### DIFF
--- a/src/inout.c
+++ b/src/inout.c
@@ -137,6 +137,7 @@ int H2T_loadMesh(MMG5_pMesh mmgMesh,int** tabhex,char *filename) {
   MMG5_int         v0, v1;
 
   posnp = posna = posnhex = posnr = 0;
+  np = nhex = na = nr = 0;
 
   strcpy(data,filename);
   if( !(inm = fopen(data,"r")) ) {


### PR DESCRIPTION
This missing initialization was leading to a segmentation fault when the input mesh did not have edges and/or ridges.