### PR TITLE
Correction of reading .npy files

### DIFF
--- a/src/hashhexa.c
+++ b/src/hashhexa.c
@@ -249,7 +249,7 @@ int H2T_hashQuad(MMG5_pMesh mesh,MMG5_Hash *hash) {
  */
 int H2T_hashGetRef(MMG5_pMesh mesh,MMG5_Hash *hash) {
   MMG5_pTetra pt;
-  int         *adja;
+  MMG5_int         *adja;
   int         ie,i,nt,ia,ib,ic,k,ref;
 
   /* Create tetrahedra adjacency */

--- a/src/inout.c
+++ b/src/inout.c
@@ -25,8 +25,8 @@ int H2T_loadNpy(MMG5_pMesh mmgMesh, int** tabhex, char* filename) {
   FILE* inm;
   unsigned char buffer = 0x00;
   char* str = NULL;
-  int pos1, pos2, dim = 0, t[3], nhex;
-  MMG5_int np, ne, i, j, k, ref, pos;
+  int pos1, pos2, dim = 0, t[3];
+  MMG5_int nhex, np, ne, i, j, k, ref, pos;
 
   /* Input data and creation of the hexa array */
   if( !(inm = fopen(mmgMesh->namein,"rb")) ) {
@@ -84,6 +84,7 @@ int H2T_loadNpy(MMG5_pMesh mmgMesh, int** tabhex, char* filename) {
   /* Point coordinates from grid indices */
   ref = 0;
   pos = 0;
+  fprintf(stdout,"  READING %" MMG5_PRId " VERTICES\n",np);
   for (i=0;i<t[0];i++) {
     for (j=0;j<t[1];j++) {
       for (k=0;k<t[2];k++) {
@@ -96,6 +97,7 @@ int H2T_loadNpy(MMG5_pMesh mmgMesh, int** tabhex, char* filename) {
 
   /* Hexahedra */
   pos = 1;
+  fprintf(stdout,"  READING %" MMG5_PRId " HEXA\n",nhex);
   for ( i=0; i<t[0]-1; ++i ) {
     for ( j=0; j<t[1]-1; ++j ) {
       for ( k=0; k<t[2]-1; ++k ) {
@@ -121,6 +123,7 @@ int H2T_loadNpy(MMG5_pMesh mmgMesh, int** tabhex, char* filename) {
   /* Edges */
   ref = 0;
   pos = 0;
+  fprintf(stdout,"  READING %" MMG5_PRId " EDGES\n",ne);
   for (i=0;i<t[0]-1; ++i) {
     int np0, np1;
     np0 = H2T_npy_point_index(i  ,0     ,0  ,t);
@@ -179,6 +182,7 @@ int H2T_loadNpy(MMG5_pMesh mmgMesh, int** tabhex, char* filename) {
   }
 
   /* Ridges */
+  fprintf(stdout,"  READING %" MMG5_PRId " RIDGES\n",ne);
   for (i=1;i<=ne;i++) {
     MMG3D_Set_ridge(mmgMesh,i);
   }


### PR DESCRIPTION
### Input files in .npy format are now correctly read.

In previous versions, it was considered that the array size specified in the header of the .npy file corresponded to the number of vertices in the mesh. However, since references (array entries) are given to hexahedra, this led to leaving unused every entry in the array corresponding to the last index in each dimension.
Hence, the number of vertices and hexahedra in every dimension have been increased by one.

### Data reading has been modified from `int16_t` type to `uint32_t`.

This modification is not enough to ensure proper reading for every type of data entry (`int64` for instance). Another update will shortly be made in order to correct this.

### Some `int` have been changed to `MMG5_int`.
### Added some standard output lines.
### Example

A example is provided here. The file `small-example.npy` is 4 x 4 x 4 array containing integers from 1 to 64. Running hex2tet without the update leads to an incorrect output file: most references do not appear in the mesh. This problem was caused both by the offset between the number of hexahedra and vertices and the data type that was read.
[small-example.tar.gz](https://github.com/MmgTools/hex2tet/files/14312682/small-example.tar.gz)

### Warning

Since it is necessary for mmg to have a cell-centered distribution of the references, this update renders the use of a vertex-centered level-set function unusable with the output tetrahedral mesh. 